### PR TITLE
python3 compatibility

### DIFF
--- a/zabbix/sender.py
+++ b/zabbix/sender.py
@@ -1,8 +1,11 @@
-import ConfigParser
+import configparser
 import json
 import logging
 import socket
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import struct
 import time
 


### PR DESCRIPTION
ConfigParse change its name in python3 and StringIO is not a module anymore.